### PR TITLE
Improve: change return type to string literal

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,7 @@ export interface Config {
 
 export interface Translation {
   key: string;
+  value: string;
   interpolations: string[];
 }
 

--- a/src/lib/__tests__/astTest.ts
+++ b/src/lib/__tests__/astTest.ts
@@ -14,6 +14,7 @@ describe('ast', () => {
         {
           interpolations: ['value'],
           key: 'common.cancel',
+          value: 'Cancel {{value}}',
         },
       ]);
       const expected = readFile('./src/lib/__tests__/expected/one-key.d.ts');
@@ -25,10 +26,12 @@ describe('ast', () => {
         {
           interpolations: ['value'],
           key: 'common.cancel',
+          value: 'Cancel {{value}}',
         },
         {
           interpolations: [],
           key: 'common.ok',
+          value: 'OK'
         },
       ]);
       const expected = readFile(

--- a/src/lib/__tests__/expected/multiple-keys.d.ts
+++ b/src/lib/__tests__/expected/multiple-keys.d.ts
@@ -8,8 +8,8 @@ declare module "react-native-i18n" {
     function currentLocale(): string;
     function t(key: "common.cancel", opts: {
         value: any;
-    }): string;
-    function t(key: "common.ok"): string;
+    }): "Cancel {{value}}";
+    function t(key: "common.ok"): "OK";
 }
 
 declare module "*.json" {

--- a/src/lib/__tests__/expected/one-key.d.ts
+++ b/src/lib/__tests__/expected/one-key.d.ts
@@ -8,7 +8,7 @@ declare module "react-native-i18n" {
     function currentLocale(): string;
     function t(key: "common.cancel", opts: {
         value: any;
-    }): string;
+    }): "Cancel {{value}}";
 }
 
 declare module "*.json" {

--- a/src/lib/__tests__/parserTest.ts
+++ b/src/lib/__tests__/parserTest.ts
@@ -30,6 +30,7 @@ describe('parser', () => {
         {
           interpolations: [],
           key: 'common.cancel',
+          value: "Cancel"
         },
       ]);
     });
@@ -45,6 +46,7 @@ describe('parser', () => {
         {
           interpolations: ['value'],
           key: 'common.cancel',
+          value: "Cancel {{value}}",
         },
       ]);
     });

--- a/src/lib/ast.ts
+++ b/src/lib/ast.ts
@@ -112,15 +112,15 @@ const tFuncParameters = (key: Translation): ts.ParameterDeclaration[] => {
   }
 };
 
-const tFunc = (key: Translation): ts.FunctionDeclaration =>
+const tFunc = (t: Translation): ts.FunctionDeclaration =>
   ts.createFunctionDeclaration(
     undefined,
     undefined,
     undefined,
     't',
     undefined,
-    tFuncParameters(key),
-    ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+    tFuncParameters(t),
+    ts.createLiteralTypeNode(ts.createLiteral(t.value)),
     undefined,
   );
 

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -26,7 +26,7 @@ export const flattenKeys = (
       flattenKeys(value, flatKey, result);
     } else {
       const interpolations = extractInterpolations(value);
-      result.push({ key: flatKey, interpolations });
+      result.push({ key: flatKey, value, interpolations });
     }
   });
   return result;


### PR DESCRIPTION
## Overview

This PR improves traceability between string resource and type definition file.

For now, you can figure out **which key exists in string resource** but can't discover a relation between key and value.

It means you may have to move around resource json file and view every time you want to use new string resource..to solve the problem this PR changes return type to string literal, now you can leverage IDE power!

<img width="742" alt="screen shot 2018-11-27 at 21 55 13" src="https://user-images.githubusercontent.com/471318/49083260-74493500-f28f-11e8-8513-3f2e95e5f85f.png">

Generated file would be like below.

```diff
declare module "react-native-i18n" {
    var fallbacks: boolean;
    var translations: {
        [keys: string]: any;
    };
-    function t(key: "title"): string;
+    function t(key: "title"): 'Example';
}
```