### PR TITLE
Pluralization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ In the watch mode, i18n-dts watches update of model file and generates d.ts file
 i18n-dts --watch
 ```
 
+### Custom pluralization keys
+
+The [i18n-js](https://github.com/fnando/i18n-js) library supports defining your own pluralization rules. If you've added or changed the rules, you might need to override the default keys (zero, one, other) that i18n-dts looks for to determine if a string should be treated as a pluralized definition. To do this, use the `--pluralization-keys <keys>` (shorthand `-k`) flag with a list of comma-separated keys.
+
+```sh
+i18n-dts --pluralization-keys zero,one,other,many
+```
+
 ## Licence
 
 ```

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -8,7 +8,14 @@ import { getConfigFromPackageJson, getTranslationFromModel } from '../lib/file';
 import { generate } from '../lib/generate';
 import { watch } from '../lib/watch';
 
-program.option('-w, --watch', 'watch file change').parse(process.argv);
+program
+  .option('-w, --watch', 'watch file change')
+  .option(
+    '-k, --pluralization-keys <keys>',
+    'customize keys used for pluralization, comma separated e.g. "few,many"',
+    value => value.split(','),
+  )
+  .parse(process.argv);
 
 const configOrError = getConfigFromPackageJson(process.cwd());
 if (configOrError instanceof Error) {
@@ -20,8 +27,9 @@ const config = configOrError as Config;
 const modelPath = path.resolve(config.model);
 const outputPath = path.resolve(config.outputDir);
 
+const { pluralizationKeys } = program;
 if (program.watch) {
-  watch(modelPath, outputPath);
+  watch(modelPath, outputPath, { pluralizationKeys });
 } else {
   const translationOrError = getTranslationFromModel(modelPath);
   if (translationOrError instanceof Error) {
@@ -29,7 +37,7 @@ if (program.watch) {
     process.exit(1);
   }
   const translation = translationOrError as JsonObject;
-  generate(translation, outputPath)
+  generate(translation, outputPath, { pluralizationKeys })
     .then(() =>
       console.info(`Emitted: ${path.join(outputPath, OUTPUT_FILE_NAME)}`),
     )

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,4 +4,5 @@ export const CONFIG_NAME = `i18n-dts`;
 export const OUTPUT_FILE_NAME = `${MODULE_NAME}.d.ts`;
 export const PACKAGE_JSON = 'package.json';
 export const INTERPOLATION_PATTERN = /(?:\{\{|%\{)([a-zA-Z0-9]+)(?:\}\}?)/;
+export const PLURALIZATION_KEYS = ['zero', 'one', 'other'];
 export const NEWLINE = '\n\n';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,5 +3,5 @@ export const MODULE_NAME = 'i18n-js';
 export const CONFIG_NAME = `i18n-dts`;
 export const OUTPUT_FILE_NAME = `${MODULE_NAME}.d.ts`;
 export const PACKAGE_JSON = 'package.json';
-export const INTERPOLATION_PATTERN = /\{\{([a-zA-Z0-9]+)\}\}/;
+export const INTERPOLATION_PATTERN = /(?:\{\{|%\{)([a-zA-Z0-9]+)(?:\}\}?)/;
 export const NEWLINE = '\n\n';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,5 @@ export const CONFIG_NAME = `i18n-dts`;
 export const OUTPUT_FILE_NAME = `${MODULE_NAME}.d.ts`;
 export const PACKAGE_JSON = 'package.json';
 export const INTERPOLATION_PATTERN = /(?:\{\{|%\{)([a-zA-Z0-9]+)(?:\}\}?)/;
-export const PLURALIZATION_KEYS = ['zero', 'one', 'other'];
+export const DEFAULT_PLURALIZATION_KEYS = ['zero', 'one', 'other'];
 export const NEWLINE = '\n\n';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,7 +5,7 @@ export interface Config {
 
 export interface Translation {
   key: string;
-  value: string;
+  value: string | string[];
   interpolations: string[];
 }
 

--- a/src/lib/__tests__/astTest.ts
+++ b/src/lib/__tests__/astTest.ts
@@ -39,5 +39,19 @@ describe('ast', () => {
       );
       expect(actual).toEqual(expected);
     });
+
+    it('returns dts file with union types', () => {
+      const actual = dts([
+        {
+          interpolations: ['count'],
+          key: 'common.items',
+          value: ['One item.', '{{count}} items.'],
+        },
+      ]);
+      const expected = readFile(
+        './src/lib/__tests__/expected/union-types.d.ts',
+      );
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/src/lib/__tests__/astTest.ts
+++ b/src/lib/__tests__/astTest.ts
@@ -31,7 +31,7 @@ describe('ast', () => {
         {
           interpolations: [],
           key: 'common.ok',
-          value: 'OK'
+          value: 'OK',
         },
       ]);
       const expected = readFile(
@@ -46,6 +46,11 @@ describe('ast', () => {
           interpolations: ['count'],
           key: 'common.items',
           value: ['One item.', '{{count}} items.'],
+        },
+        {
+          interpolations: [],
+          key: 'common.uncountedItems',
+          value: ['One item.', 'Many items.'],
         },
       ]);
       const expected = readFile(

--- a/src/lib/__tests__/expected/union-types.d.ts
+++ b/src/lib/__tests__/expected/union-types.d.ts
@@ -1,0 +1,17 @@
+declare module "i18n-js" {
+    var fallbacks: boolean;
+    var translations: {
+        [keys: string]: any;
+    };
+    var defaultLocale: string;
+    var locale: string;
+    function currentLocale(): string;
+    function t(key: "common.items", opts: {
+        count: any;
+    }): "One item." | "{{count}} items.";
+}
+
+declare module "*.json" {
+    const value: any;
+    export default value;
+}

--- a/src/lib/__tests__/expected/union-types.d.ts
+++ b/src/lib/__tests__/expected/union-types.d.ts
@@ -9,6 +9,7 @@ declare module "i18n-js" {
     function t(key: "common.items", opts: {
         count: any;
     }): "One item." | "{{count}} items.";
+    function t(key: "common.uncountedItems"): "One item." | "Many items.";
 }
 
 declare module "*.json" {

--- a/src/lib/__tests__/parserTest.ts
+++ b/src/lib/__tests__/parserTest.ts
@@ -76,6 +76,28 @@ describe('parser', () => {
         },
       ]);
     });
+
+    it('handles pluralized objects with custom pluralization keys', () => {
+      expect(
+        flattenKeys(
+          {
+            common: {
+              items: {
+                one: 'One {{type}} item.',
+                many: 'Many {{type}} items.',
+              },
+            },
+          },
+          ['one', 'many'],
+        ),
+      ).toEqual([
+        {
+          interpolations: ['count', 'type', 'type'],
+          key: 'common.items',
+          value: ['One {{type}} item.', 'Many {{type}} items.'],
+        },
+      ]);
+    });
   });
 
   describe('isPluralized', () => {
@@ -108,6 +130,38 @@ describe('parser', () => {
           zero: 'test',
           somethingElse: 'test',
         }),
+      ).toEqual(false);
+    });
+
+    it('supports overriding pluralization keys with the second argument', () => {
+      expect(
+        isPluralized(
+          {
+            few: 'test',
+          },
+          ['few', 'many'],
+        ),
+      ).toEqual(true);
+
+      expect(
+        isPluralized(
+          {
+            few: 'test',
+            many: 'test',
+          },
+          ['few', 'many'],
+        ),
+      ).toEqual(true);
+
+      expect(
+        isPluralized(
+          {
+            few: 'test',
+            many: 'test',
+            other: 'test',
+          },
+          ['few', 'many'],
+        ),
       ).toEqual(false);
     });
 

--- a/src/lib/__tests__/parserTest.ts
+++ b/src/lib/__tests__/parserTest.ts
@@ -83,13 +83,24 @@ describe('parser', () => {
       expect(
         isPluralized({
           one: 'test',
+        }),
+      ).toEqual(true);
+      expect(
+        isPluralized({
+          other: 'test',
+          zero: 'test',
+        }),
+      ).toEqual(true);
+      expect(
+        isPluralized({
+          one: 'test',
           other: 'test',
           zero: 'test',
         }),
       ).toEqual(true);
     });
 
-    it('returns false for objects that containa keys that are not pluralization keys', () => {
+    it('returns false for objects that contain keys that are not pluralization keys', () => {
       expect(
         isPluralized({
           one: 'test',

--- a/src/lib/__tests__/parserTest.ts
+++ b/src/lib/__tests__/parserTest.ts
@@ -1,4 +1,4 @@
-import { extractInterpolations, flattenKeys } from '../parser';
+import { extractInterpolations, flattenKeys, isPluralized } from '../parser';
 
 describe('parser', () => {
   describe('extractInterpolations', () => {
@@ -12,6 +12,13 @@ describe('parser', () => {
 
     it('returns multiple matched strings', () => {
       expect(extractInterpolations('{{test}} {{test1}}')).toEqual([
+        'test',
+        'test1',
+      ]);
+    });
+
+    it('supports both interpolation syntaxes', () => {
+      expect(extractInterpolations('{{test}} %{test1}')).toEqual([
         'test',
         'test1',
       ]);
@@ -30,7 +37,7 @@ describe('parser', () => {
         {
           interpolations: [],
           key: 'common.cancel',
-          value: "Cancel"
+          value: 'Cancel',
         },
       ]);
     });
@@ -46,9 +53,55 @@ describe('parser', () => {
         {
           interpolations: ['value'],
           key: 'common.cancel',
-          value: "Cancel {{value}}",
+          value: 'Cancel {{value}}',
         },
       ]);
+    });
+
+    it('handles pluralized objects', () => {
+      expect(
+        flattenKeys({
+          common: {
+            items: {
+              one: 'One {{type}} item.',
+              other: 'Many {{type}} items.',
+            },
+          },
+        }),
+      ).toEqual([
+        {
+          interpolations: ['count', 'type', 'type'],
+          key: 'common.items',
+          value: ['One {{type}} item.', 'Many {{type}} items.'],
+        },
+      ]);
+    });
+  });
+
+  describe('isPluralized', () => {
+    it('returns true for objects that only contain pluralization keys', () => {
+      expect(
+        isPluralized({
+          one: 'test',
+          other: 'test',
+          zero: 'test',
+        }),
+      ).toEqual(true);
+    });
+
+    it('returns false for objects that containa keys that are not pluralization keys', () => {
+      expect(
+        isPluralized({
+          one: 'test',
+          other: 'test',
+          zero: 'test',
+          somethingElse: 'test',
+        }),
+      ).toEqual(false);
+    });
+
+    it('returns false for empty objects', () => {
+      expect(isPluralized({})).toEqual(false);
     });
   });
 });

--- a/src/lib/ast.ts
+++ b/src/lib/ast.ts
@@ -120,7 +120,13 @@ const tFunc = (t: Translation): ts.FunctionDeclaration =>
     't',
     undefined,
     tFuncParameters(t),
-    ts.createLiteralTypeNode(ts.createLiteral(t.value)),
+    Array.isArray(t.value)
+      ? ts.createUnionTypeNode(
+          t.value.map((value: string) =>
+            ts.createLiteralTypeNode(ts.createLiteral(value)),
+          ),
+        )
+      : ts.createLiteralTypeNode(ts.createLiteral(t.value)),
     undefined,
   );
 

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -6,14 +6,19 @@ import { JsonObject } from '../interfaces';
 import { dts } from './ast';
 import { flattenKeys } from './parser';
 
+export interface GenerateOptions {
+  pluralizationKeys?: string[];
+}
+
 export const generate = (
   translations: JsonObject,
   dirPath: string,
+  options: GenerateOptions = {},
 ): Promise<void> => {
   if (!existsSync(dirPath)) {
     mkdirp.sync(dirPath);
   }
-  const keys = flattenKeys(translations);
+  const keys = flattenKeys(translations, options.pluralizationKeys);
   const data = dts(keys);
   const outputPath = path.join(dirPath, OUTPUT_FILE_NAME);
   return execWriteFile(outputPath, data);

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,7 +1,8 @@
 import { INTERPOLATION_PATTERN, PLURALIZATION_KEYS } from '../constants';
 import { JsonObject, Translation } from '../interfaces';
 
-const isPluralized = (json: JsonObject) =>
+export const isPluralized = (json: JsonObject) =>
+  Object.keys(json).length > 0 &&
   Object.keys(json).every(key => PLURALIZATION_KEYS.includes(key));
 
 export const extractInterpolations = (str: string): string[] => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,9 +1,15 @@
-import { INTERPOLATION_PATTERN, PLURALIZATION_KEYS } from '../constants';
+import {
+  INTERPOLATION_PATTERN,
+  DEFAULT_PLURALIZATION_KEYS,
+} from '../constants';
 import { JsonObject, Translation } from '../interfaces';
 
-export const isPluralized = (json: JsonObject) =>
+export const isPluralized = (
+  json: JsonObject,
+  pluralizationKeys = DEFAULT_PLURALIZATION_KEYS,
+) =>
   Object.keys(json).length > 0 &&
-  Object.keys(json).every(key => PLURALIZATION_KEYS.includes(key));
+  Object.keys(json).every(key => pluralizationKeys.includes(key));
 
 export const extractInterpolations = (str: string): string[] => {
   const interpolations = [];
@@ -20,6 +26,7 @@ export const extractInterpolations = (str: string): string[] => {
 
 export const flattenKeys = (
   json: JsonObject,
+  pluralizationKeys?: string[],
   prefix: string | undefined = undefined,
   result: Translation[] = [],
 ): Translation[] => {
@@ -27,7 +34,7 @@ export const flattenKeys = (
     const flatKey = prefix ? `${prefix}.${key}` : key;
     const value = json[key];
     if (typeof value === 'object') {
-      if (isPluralized(value)) {
+      if (isPluralized(value, pluralizationKeys)) {
         let interpolations = ['count'];
         const values: string[] = [];
         Object.keys(value).map(key => {
@@ -39,7 +46,7 @@ export const flattenKeys = (
         });
         result.push({ key: flatKey, value: values, interpolations });
       } else {
-        flattenKeys(value, flatKey, result);
+        flattenKeys(value, pluralizationKeys, flatKey, result);
       }
     } else {
       const interpolations = extractInterpolations(value);

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -3,9 +3,13 @@ import * as path from 'path';
 import { OUTPUT_FILE_NAME } from '../constants';
 import { JsonObject } from '../interfaces';
 import { getTranslationFromModel } from './file';
-import { generate } from './generate';
+import { generate, GenerateOptions } from './generate';
 
-export const watch = (filePath: string, outputPath: string) => {
+export const watch = (
+  filePath: string,
+  outputPath: string,
+  generateOptions?: GenerateOptions,
+) => {
   console.info(`Start watching: ${filePath}`);
 
   watchFile(filePath, (current, prev) => {
@@ -19,7 +23,7 @@ export const watch = (filePath: string, outputPath: string) => {
       console.error(translationOrError.message);
     }
     const translation = translationOrError as JsonObject;
-    generate(translation, outputPath)
+    generate(translation, outputPath, generateOptions)
       .then(() =>
         console.info(`Emitted: ${path.join(outputPath, OUTPUT_FILE_NAME)}`),
       )


### PR DESCRIPTION
Add support for strings that use the pluralization feature of i18n-js. From this input: 
```
{
  "common": {
    "items": {
      "one": "One item.",
      "other": "{{count}} items."
  }
}
```
We don't want to interpret this as two strings `"common.items.one"` and `"common.items.other"` as it does currently, but rather collapse them into one string `"common.items"` with a `count` parameter, returning either `"One item."` or ` "{{count}} items."`. 

To do this, we assume that a key that contains an object with *only* keys `"zero"`, `"one"` or  `"other"` to be in pluralized form. This might however end up being a breaking change if someone was previously using this library and not expecting these keys to be collapsed into the parent as they will with this PR.
 
We needed to add this feature to make this library fit our needs, and it's been working out great. Happy to hear if you'll consider merging this so we can drop our fork. :) 


