### PR TITLE
Make sure the latest uncached translation file is read when using --watch

### DIFF
--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -35,6 +35,7 @@ export const getTranslationFromModel = (
   }
   const extname = path.extname(filePath);
   if (isJson(extname) || isSource(extname)) {
+    delete require.cache[require.resolve(filePath)];
     return require(filePath) as JsonObject;
   }
   return Error('file extension type should be either .json or .ts|.js');


### PR DESCRIPTION
I noticed a bug where you would stop getting the latest changes from a file after the first refresh when using watch mode. This is due to `require()` calls being cached in Node.js, so we need delete the cache entry each time we import the file again.  